### PR TITLE
[FIX]: absolute paths to relative paths

### DIFF
--- a/src/partials/header.html
+++ b/src/partials/header.html
@@ -1,4 +1,4 @@
 <header>
-  <a href="/">Home</a>
-  <a href="/contact.html">Contact</a>
+  <a href="./">Home</a>
+  <a href="./contact.html">Contact</a>
 </header>


### PR DESCRIPTION
So links don't break when published to Github Pages, which [serves the website with a base_url](https://mademistakes.com/mastering-jekyll/site-url-baseurl/)